### PR TITLE
Updated templates.json (compatibility with 2.20.x and beyond)

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -5438,34 +5438,32 @@
 					"name": "YTDL_PROXY"
 				},
 				{
-					"default": true,
 					"label": "YTDL_WRITEINFOJSON",
 					"name": "YTDL_WRITEINFOJSON",
 					"select": [
 						{
 							"text": "Enabled",
-							"value": true,
+							"value": "true",
 							"default": true
 						},
 						{
 							"text": "Disabled",
-							"value": false
+							"value": "false"
 						}
 					]
 				},
 				{
-					"default": false,
 					"label": "YTDL_VERBOSE",
 					"name": "YTDL_VERBOSE",
 					"select": [
 						{
 							"text": "Disabled",
-							"value": false,
+							"value": "false",
 							"default": true
 						},
 						{
 							"text": "Enabled",
-							"value": true
+							"value": "true"
 						}
 					]
 				},
@@ -5532,34 +5530,32 @@
 					"name": "YTDL_PROXY"
 				},
 				{
-					"default": true,
 					"label": "YTDL_WRITEINFOJSON",
 					"name": "YTDL_WRITEINFOJSON",
 					"select": [
 						{
 							"text": "Enabled",
-							"value": true,
+							"value": "true",
 							"default": true
 						},
 						{
 							"text": "Disabled",
-							"value": false
+							"value": "false"
 						}
 					]
 				},
 				{
-					"default": false,
 					"label": "YTDL_VERBOSE",
 					"name": "YTDL_VERBOSE",
 					"select": [
 						{
 							"text": "Disabled",
-							"value": false,
+							"value": "false",
 							"default": true
 						},
 						{
 							"text": "Enabled",
-							"value": true
+							"value": "true"
 						}
 					]
 				},


### PR DESCRIPTION
- Removed extraneous "default" fields in the Media Grabber definitions; since they have "select" fields, the default option is chosen there. Otherwise the JSON fails to be parsed by Portainer.
- All select -> value options must be strings, even if denoting a boolean

The templates had slight issues in that they had `default` fields directly within the `env` fields which also had `select` definitions. The `select` fields define the default option used by marking one object within that array as having `"default": true`, negating the need for the `default` field above. In addition, the `value`s being used inside the `select` fields were bare booleans, which Portainer does not successfully parse in this context; it expects strings, even if they are the string representation of a bool.

Tested against Portainer CE 2.20.3. Note that the actual operation of these changes has not been tested (ie. if the templated container interprets the string argument properly); only that the template JSON definition is parsed and usable as is in Portainer. This is also a prerelease version of Portainer; however, the fixes are submitted now as they also work on 2.19.5 (currently tagged as latest).